### PR TITLE
set non-zero exit code if increase in missed lines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* return non-zero exit code if uncovered lines rises (previously based on line
+  rate)
+
 ## 0.4.0 (2015-01-04)
 
 * rename `Cobertura.total_lines()` -> `Cobertura.total_statements()`

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -115,5 +115,6 @@ def diff(
     click.echo(report, file=output, nl=isatty)
 
     # non-zero exit code if line rate worsened
-    exit_code = cobertura1.line_rate() > cobertura2.line_rate()
+    differ = reporter.differ
+    exit_code = differ.diff_total_misses() > 0
     raise SystemExit(exit_code)


### PR DESCRIPTION
The line rate (percentage of covered lines) can legitimately go down for a number of reasons. To illustrate, suppose we have this code coverage report for version A of our code:

```
line 1: hit
line 2: hit
line 3: miss
line 4: hit
line 5: hit
```

Here, the line rate is 80% and uncovered lines is 1 (miss). Later in version B of our code, the following coverage report is generated:

```
line 1: hit
### line deleted ###
line 2: miss
line 3: hit
line 4: hit
```

Now the line rate is 75% and uncovered lines is still 1. In this case, failing the build based on line rate would be inappropriate, thus making the line rate the wrong metric to fail a build.

The basic idea is that a code base may have technical debt of N uncovered lines and you want to prevent N from ever going up.