### PR TITLE
improve xpath class name lookup performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Options of pycobertura diff `--missed` and `--no-missed` have been renamed to
   `--source` and `--no-source` which will not show the source code nor display
   missing lines since they cannot be accurately computed without the source.
+* Optimized xpath syntax for faster class name lookup (~3x)
 
 ## 0.5.0 (2015-01-07)
 

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -29,7 +29,8 @@ class Cobertura(object):
         self.xml = ET.parse(xml_path).getroot()
 
     def _get_element_by_class_name(self, class_name):
-        return self.xml.xpath("//class[@name='%s'][1]" % class_name)[0]
+        syntax = "./packages/package/classes/class[@name='%s'][1]" % class_name
+        return self.xml.xpath(syntax)[0]
 
     def _get_lines_by_class_name(self, class_name):
         el = self._get_element_by_class_name(class_name)


### PR DESCRIPTION
Improved by over ~3x. Might be more dramatic on large Cobertura reports.

```bash
python -m timeit -s "import lxml.etree as ET; xml = ET.parse('coverage.xml').getroot()" "xml.xpath('//class[@name=\"foo\"][1]')"
10000 loops, best of 3: 41.8 usec per loop
```

vs.

```bash
python -m timeit -s "import lxml.etree as ET; xml = ET.parse('coverage.xml').getroot()" "xml.xpath('./packages/package/classes/class[@name=\"foo\"][1]')"
100000 loops, best of 3: 12.7 usec per loop
```