### PR TITLE
exit code is non-zero until all changes are covered

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
   missing lines since they cannot be accurately computed without the source.
 * Optimized xpath syntax for faster class name lookup (~3x)
 * Colorize total missed statements
+* `pycobertura diff` exit code will be non-zero until all changes are covered
 
 ## 0.5.0 (2015-01-07)
 

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -130,5 +130,5 @@ def diff(
 
     # non-zero exit code if line rate worsened
     differ = reporter.differ
-    exit_code = differ.diff_total_misses() > 0
+    exit_code = not differ.has_all_changes_covered()
     raise SystemExit(exit_code)

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -235,6 +235,20 @@ class CoberturaDiff(object):
         self.cobertura1 = cobertura1
         self.cobertura2 = cobertura2
 
+    def has_all_changes_covered(self):
+        """
+        Return `True` if all changes in the diff are covered, `False`
+        otherwise.
+
+        This goes over every individual classes and checks whether missed
+        statements are present. Looking at the just the total missed statements
+        would be inaccurate since it could still include uncovered lines.
+        """
+        for class_name in self.classes():
+            if self.diff_total_misses(class_name) > 0:
+                return False
+        return True
+
     def diff_total_statements(self, class_name=None):
         if class_name is None:
             statements1 = self.cobertura1.total_statements(class_name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,23 +264,25 @@ def test_diff__same_coverage_has_exit_status_of_zero():
     assert result.exit_code == 0
 
 
-def test_diff__better_coverage_has_exit_status_of_zero():
+def test_diff__all_changes_covered_has_exit_status_of_zero():
     from pycobertura.cli import diff
 
     runner = CliRunner()
     result = runner.invoke(diff, [
-        'tests/dummy.source1/coverage.xml',
-        'tests/dummy.source2/coverage.xml',
+        'tests/dummy.original.xml',
+        'tests/dummy.original-full-cov.xml',  # has no uncovered lines
+        '--no-source',
     ], catch_exceptions=False)
     assert result.exit_code == 0
 
 
-def test_diff__worse_coverage_has_exit_status_of_one():
+def test_diff__not_all_changes_covered_has_exit_status_of_one():
     from pycobertura.cli import diff
 
     runner = CliRunner()
     result = runner.invoke(diff, [
-        'tests/dummy.source2/coverage.xml',
-        'tests/dummy.source1/coverage.xml',
+        'tests/dummy.with-dummy2-no-cov.xml',
+        'tests/dummy.with-dummy2-better-and-worse.xml',  # has covered AND uncovered lines
+        '--no-source',
     ], catch_exceptions=False)
     assert result.exit_code == 1


### PR DESCRIPTION
Looking at the just the total missed statements would be inaccurate since it could still include uncovered lines.