### PR TITLE
README.md: Make badges link to PyPI and Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A Cobertura coverage parser that can diff reports and show coverage progress.
 
-![Travis](http://img.shields.io/travis/SurveyMonkey/pycobertura.svg?style=flat)
-![PyPI](http://img.shields.io/pypi/v/pycobertura.svg?style=flat)
+[![Travis](http://img.shields.io/travis/SurveyMonkey/pycobertura.svg?style=flat)](https://travis-ci.org/SurveyMonkey/pycobertura)
+[![PyPI](http://img.shields.io/pypi/v/pycobertura.svg?style=flat)](https://pypi.python.org/pypi/pycobertura)
 
 * [About](#about)
 * [Features](#features)


### PR DESCRIPTION
so clicking them goes to PyPI and Travis instead of opening the image in the browser.

Try it out at https://github.com/msabramo/pycobertura/blob/README_make_badges_link_to_pypi_and_travis/README.md