### PR TITLE
diff won't report classes with no changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * expose `CoberturaDiff` under the pycobertura namespace
+* pycobertura diff no longer reports unchanged classes
 
 ## 0.5.2 (2015-01-13)
 

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -163,7 +163,8 @@ class DeltaReporter(object):
 
         for class_name in self.differ.classes():
             class_row = self.get_class_row(class_name)
-            lines.append(class_row)
+            if any(class_row[1:]):  # don't report unchanged classes
+                lines.append(class_row)
 
         footer = self.get_footer_row()
         lines.append(footer)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,23 +86,21 @@ def test_diff__format_default():
     # FIXME: Fails in PY2, requires click>=4.x to pass
     if not PY2:
         assert result.output == """\
-Name            Stmts    Miss    Cover    Missing
---------------  -------  ------  -------  ----------
-dummy/__init__  -        -       -
-dummy/dummy     -        \x1b[32m-2\x1b[39m      +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2    +2       \x1b[31m+1\x1b[39m      -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
-dummy/dummy3    +2       \x1b[31m+2\x1b[39m      -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL           +4       \x1b[31m+1\x1b[39m      +15.00%
+Name          Stmts      Miss  Cover    Missing
+------------  -------  ------  -------  ----------
+dummy/dummy   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
+dummy/dummy2  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+dummy/dummy3  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+TOTAL         +4           \x1b[31m+1\x1b[39m  +15.00%
 """
     else:
         assert result.output == """\
-Name            Stmts    Miss    Cover    Missing
---------------  -------  ------  -------  ----------
-dummy/__init__  -        -       -
-dummy/dummy     -        -2      +40.00%  -5, -6
-dummy/dummy2    +2       +1      -25.00%  -2, -4, +5
-dummy/dummy3    +2       +2      -        +1, +2
-TOTAL           +4       +1      +15.00%
+Name          Stmts      Miss  Cover    Missing
+------------  -------  ------  -------  ----------
+dummy/dummy   -            -2  +40.00%  -5, -6
+dummy/dummy2  +2           +1  -25.00%  -2, -4, +5
+dummy/dummy3  +2           +2  -        +1, +2
+TOTAL         +4           +1  +15.00%
 """
 
 
@@ -119,23 +117,21 @@ def test_diff__format_text():
         # FIXME: Fails in PY2, requires click>=4.x to pass
         if not PY2:
             assert result.output == """\
-Name            Stmts    Miss    Cover    Missing
---------------  -------  ------  -------  ----------
-dummy/__init__  -        -       -
-dummy/dummy     -        \x1b[32m-2\x1b[39m      +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2    +2       \x1b[31m+1\x1b[39m      -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
-dummy/dummy3    +2       \x1b[31m+2\x1b[39m      -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL           +4       \x1b[31m+1\x1b[39m      +15.00%
+Name          Stmts      Miss  Cover    Missing
+------------  -------  ------  -------  ----------
+dummy/dummy   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
+dummy/dummy2  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+dummy/dummy3  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+TOTAL         +4           \x1b[31m+1\x1b[39m  +15.00%
 """
         else:
             assert result.output == """\
-Name            Stmts    Miss    Cover    Missing
---------------  -------  ------  -------  ----------
-dummy/__init__  -        -       -
-dummy/dummy     -        -2      +40.00%  -5, -6
-dummy/dummy2    +2       +1      -25.00%  -2, -4, +5
-dummy/dummy3    +2       +2      -        +1, +2
-TOTAL           +4       +1      +15.00%
+Name          Stmts      Miss  Cover    Missing
+------------  -------  ------  -------  ----------
+dummy/dummy   -            -2  +40.00%  -5, -6
+dummy/dummy2  +2           +1  -25.00%  -2, -4, +5
+dummy/dummy3  +2           +2  -        +1, +2
+TOTAL         +4           +1  +15.00%
 """
 
 
@@ -155,13 +151,12 @@ def test_diff__output_to_file():
         os.remove('report.out')
         assert result.output == ""
         assert report == """\
-Name            Stmts    Miss    Cover    Missing
---------------  -------  ------  -------  ----------
-dummy/__init__  -        -       -
-dummy/dummy     -        -2      +40.00%  -5, -6
-dummy/dummy2    +2       +1      -25.00%  -2, -4, +5
-dummy/dummy3    +2       +2      -        +1, +2
-TOTAL           +4       +1      +15.00%"""
+Name          Stmts      Miss  Cover    Missing
+------------  -------  ------  -------  ----------
+dummy/dummy   -            -2  +40.00%  -5, -6
+dummy/dummy2  +2           +1  -25.00%  -2, -4, +5
+dummy/dummy3  +2           +2  -        +1, +2
+TOTAL         +4           +1  +15.00%"""
 
 
 # FIXME: when Click 4 is available, uncomment this.

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -52,13 +52,9 @@ def test_text_report_delta__no_diff():
     report_delta = TextReporterDelta(cobertura1, cobertura2)
 
     assert report_delta.generate() == """\
-Name            Stmts    Miss    Cover    Missing
---------------  -------  ------  -------  ---------
-dummy/__init__  -        -       -
-dummy/dummy     -        -       -
-dummy/dummy2    -        -       -
-dummy/dummy4    -        -       -
-TOTAL           -        -       -"""
+Name    Stmts    Miss    Cover    Missing
+------  -------  ------  -------  ---------
+TOTAL   -        -       -"""
 
 
 def test_text_report_delta__colorize_True():
@@ -70,13 +66,12 @@ def test_text_report_delta__colorize_True():
     report_delta = TextReporterDelta(cobertura1, cobertura2, color=True)
 
     assert report_delta.generate() == """\
-Name            Stmts    Miss    Cover    Missing
---------------  -------  ------  -------  ----------
-dummy/__init__  -        -       -
-dummy/dummy     -        \x1b[32m-2\x1b[39m      +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2    +2       \x1b[31m+1\x1b[39m      -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
-dummy/dummy3    +2       \x1b[31m+2\x1b[39m      -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL           +4       \x1b[31m+1\x1b[39m      +15.00%"""
+Name          Stmts      Miss  Cover    Missing
+------------  -------  ------  -------  ----------
+dummy/dummy   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
+dummy/dummy2  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+dummy/dummy3  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+TOTAL         +4           \x1b[31m+1\x1b[39m  +15.00%"""
 
 
 def test_text_report_delta__colorize_True__with_missing_range():
@@ -88,13 +83,12 @@ def test_text_report_delta__colorize_True__with_missing_range():
     report_delta = TextReporterDelta(cobertura1, cobertura2, color=True)
 
     assert report_delta.generate() == """\
-Name            Stmts    Miss    Cover    Missing
---------------  -------  ------  -------  ----------
-dummy/__init__  -        -       -
-dummy/dummy     -        \x1b[32m-2\x1b[39m      +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2    +2       \x1b[31m+1\x1b[39m      -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
-dummy/dummy3    +2       \x1b[31m+2\x1b[39m      -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL           +4       \x1b[31m+1\x1b[39m      +15.00%"""
+Name          Stmts      Miss  Cover    Missing
+------------  -------  ------  -------  ----------
+dummy/dummy   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
+dummy/dummy2  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+dummy/dummy3  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+TOTAL         +4           \x1b[31m+1\x1b[39m  +15.00%"""
 
 
 def test_text_report_delta__colorize_False():
@@ -106,13 +100,12 @@ def test_text_report_delta__colorize_False():
     report_delta = TextReporterDelta(cobertura1, cobertura2, color=False)
 
     assert report_delta.generate() == """\
-Name            Stmts    Miss    Cover    Missing
---------------  -------  ------  -------  ----------
-dummy/__init__  -        -       -
-dummy/dummy     -        -2      +40.00%  -5, -6
-dummy/dummy2    +2       +1      -25.00%  -2, -4, +5
-dummy/dummy3    +2       +2      -        +1, +2
-TOTAL           +4       +1      +15.00%"""
+Name          Stmts      Miss  Cover    Missing
+------------  -------  ------  -------  ----------
+dummy/dummy   -            -2  +40.00%  -5, -6
+dummy/dummy2  +2           +1  -25.00%  -2, -4, +5
+dummy/dummy3  +2           +2  -        +1, +2
+TOTAL         +4           +1  +15.00%"""
 
 
 def test_html_report():
@@ -237,13 +230,12 @@ def test_text_report_delta__no_source():
     report_delta = TextReporterDelta(cobertura1, cobertura2, show_source=False)
     output = report_delta.generate()
     assert output == """\
-Name            Stmts    Miss    Cover
---------------  -------  ------  -------
-dummy/__init__  -        -       -
-dummy/dummy     -        -2      +40.00%
-dummy/dummy2    +2       +1      -25.00%
-dummy/dummy3    +2       +2      -
-TOTAL           +4       +1      +15.00%"""
+Name          Stmts      Miss  Cover
+------------  -------  ------  -------
+dummy/dummy   -            -2  +40.00%
+dummy/dummy2  +2           +1  -25.00%
+dummy/dummy3  +2           +2  -
+TOTAL         +4           +1  +15.00%"""
 
 
 def test_html_report_delta__no_source():
@@ -275,12 +267,6 @@ def test_html_report_delta__no_source():
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td><a href="#dummy/__init__">dummy/__init__</a></td>
-            <td>-</td>
-            <td><span>-</span></td>
-            <td>-</td>
-          </tr>
           <tr>
             <td><a href="#dummy/dummy">dummy/dummy</a></td>
             <td>-</td>
@@ -346,14 +332,6 @@ def test_html_report_delta():
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td><a href="#dummy/__init__">dummy/__init__</a></td>
-            <td>-</td>
-            <td><span>-</span></td>
-            <td>-</td>
-            <td>
-            </td>
-          </tr>
           <tr>
             <td><a href="#dummy/dummy">dummy/dummy</a></td>
             <td>-</td>


### PR DESCRIPTION
Until now, all classes were shown in the diff report. On big project it's annoying having to scroll through many classes to find the one that has actual changes.

We are no longer rendering unchanged classes.