### PR TITLE
flake8ify setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from setuptools import setup, find_packages
 
 
@@ -23,7 +22,8 @@ setup(
     author_email="alexandre@surveymonkey.com",
     maintainer="Alex Conrad",
     maintainer_email="alexandre@surveymonkey.com",
-    description="A Cobertura coverage parser that can diff reports and show coverage progress.",
+    description="A Cobertura coverage parser that can diff reports and "
+                "show coverage progress.",
     license="MIT License",
     keywords="cobertura coverage parser parse xml",
     url="https://github.com/SurveyMonkey/pycobertura",
@@ -45,7 +45,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4"
     ],
-    entry_points = {
+    entry_points={
         'console_scripts': [
             'pycobertura=pycobertura.cli:pycobertura'
         ],


### PR DESCRIPTION
Fixes these issues:

```
[marca@marca-mac2 pycobertura]$ flake8 setup.py
setup.py:2:1: F401 'sys' imported but unused
setup.py:26:80: E501 line too long (96 > 79 characters)
setup.py:48:17: E251 unexpected spaces around keyword / parameter equals
setup.py:48:19: E251 unexpected spaces around keyword / parameter equals
```