### PR TITLE
Update toxenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,9 @@ commands =
     pip install -e .
     pip install -r test-requirements.txt
     py.test {posargs}
+setenv =
+       LANG=en_US.UTF-8
+       LC_ALL=en_US.UTF-8
 
 [testenv:pep8]
 commands =


### PR DESCRIPTION
This will make py3 tests to pass even though the Snap CI and Travis environments look properly set when we run the command `env`.

```
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment. Either switch to Python 2 or consult http://click.pocoo.org/python3/ for mitigation steps.
```