### PR TITLE
use passenv = LANG (new tox 2 feature)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ commands =
     pip install -e .
     pip install -r test-requirements.txt
     py.test {posargs}
-setenv =
-       LANG=en_US.UTF-8
-       LC_ALL=en_US.UTF-8
+
+passenv =
+       LANG
 
 [testenv:pep8]
 commands =


### PR DESCRIPTION
Tox 2 has environment variable isolation and no longer passes most of the variables from the tox invocation environment to the test environment (compared with tox 1). For Python 3 to work properly with UTF-8, the LANG variable needs to be forwarded down to the test environments.

This PR just makes it nicer so we don't redefine the variables, we just forward them.

/cc @sontek 