### PR TITLE
Added coverage v4.0.x compatibility by changing class element lookups to use 'filename' instead of the 'name' attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Release Notes
 
 ## Unreleased
+* The coverage report now displays the class's filename instead of the class's
+  name, the latter being more subject to different interpretations by coverage
+  tools. This change was done to support coverage.py versions 3.x and 4.x.
+* removed `CoberturaDiff.filename()`
 
 ## 0.8.0 (2015-09-28)
 

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ The `show` command displays the report summary of a coverage file.
 
 ```
 $ pycobertura show coverage.xml
-Name                     Stmts    Miss  Cover    Missing
----------------------  -------  ------  -------  ---------
-pycobertura/__init__         1       0  100.00%
-pycobertura/cli             18       0  100.00%
-pycobertura/cobertura       93       0  100.00%
-pycobertura/reports        129       0  100.00%
-pycobertura/utils           12       0  100.00%
-TOTAL                      253       0  100.00%
+Filename                     Stmts    Miss  Cover    Missing
+-------------------------  -------  ------  -------  ---------
+pycobertura/__init__.py          1       0  100.00%
+pycobertura/cli.py              18       0  100.00%
+pycobertura/cobertura.py        93       0  100.00%
+pycobertura/reporters.py       129       0  100.00%
+pycobertura/utils.py            12       0  100.00%
+TOTAL                          253       0  100.00%
 ```
 
 The following is a screenshot of the HTML version of another coverage file
@@ -87,11 +87,11 @@ source code that was used to generate each of the passed Cobertura reports
 
 ```
 $ pycobertura diff coverage.old.xml coverage.new.xml --source1 old_source/ --source2 new_source/
-Name          Stmts    Miss    Cover     Missing
-------------  -------  ------  --------  ---------
-dummy/dummy   -        -2      +50.00%   -2, -5
-dummy/dummy2  +2       -       +100.00%
-TOTAL         +2       -2      +50.00%
+Filename          Stmts    Miss    Cover     Missing
+----------------  -------  ------  --------  ---------
+dummy/dummy.py    -        -2      +50.00%   -2, -5
+dummy/dummy2.py   +2       -       +100.00%
+TOTAL             +2       -2      +50.00%
 ```
 
 The column `Missing` will show line numbers prefixed with either a plus sign
@@ -126,28 +126,28 @@ Using it as a library in your Python application is easy:
 from pycobertura import Cobertura
 cobertura = Cobertura('coverage.xml')
 
-cobertura.version == '3.7.1'
+cobertura.version == '4.0.2'
 cobertura.line_rate() == 1.0  # 100%
-cobertura.classes() == [
-    'pycobertura/__init__',
-    'pycobertura/cli',
-    'pycobertura/cobertura',
-    'pycobertura/reports',
-    'pycobertura/utils',
+cobertura.class_files() == [
+    'pycobertura/__init__.py',
+    'pycobertura/cli.py',
+    'pycobertura/cobertura.py',
+    'pycobertura/reporters.py',
+    'pycobertura/utils.py',
 ]
-cobertura.line_rate('pycobertura/cli') == 1.0
+cobertura.line_rate('pycobertura/cli.py') == 1.0
 
 from pycobertura import TextReporter
 tr = TextReporter(cobertura)
 tr.generate() == """\
-Name                     Stmts    Miss  Cover    Missing
----------------------  -------  ------  -------  ---------
-pycobertura/__init__         1       0  100.00%
-pycobertura/cli             18       0  100.00%
-pycobertura/cobertura       93       0  100.00%
-pycobertura/reports        129       0  100.00%
-pycobertura/utils           12       0  100.00%
-TOTAL                      253       0  100.00%"""
+Filename                     Stmts    Miss  Cover    Missing
+-------------------------  -------  ------  -------  ---------
+pycobertura/__init__.py          1       0  100.00%
+pycobertura/cli.py              18       0  100.00%
+pycobertura/cobertura.py        93       0  100.00%
+pycobertura/reporters.py       129       0  100.00%
+pycobertura/utils.py            12       0  100.00%
+TOTAL                          253       0  100.00%"""
 
 from pycobertura import TextReporterDelta
 
@@ -155,11 +155,11 @@ coverage1 = Cobertura('coverage1.xml')
 coverage2 = Cobertura('coverage2.xml')
 delta = TextReporterDelta(coverage1, coverage2)
 delta.generate() == """\
-Name          Stmts    Miss    Cover     Missing
-------------  -------  ------  --------  ---------
-dummy/dummy   -        -2      +50.00%   -2, -5
-dummy/dummy2  +2       -       +100.00%
-TOTAL         +2       -2      +50.00%"""
+Filename          Stmts    Miss    Cover     Missing
+----------------  -------  ------  --------  ---------
+dummy/dummy.py    -        -2      +50.00%   -2, -5
+dummy/dummy2.py   +2       -       +100.00%
+TOTAL             +2       -2      +50.00%"""
 ```
 
 ## How to contribute?

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -47,7 +47,7 @@ class Cobertura(object):
 
     @memoize
     def _get_element_by_class_name(self, class_name):
-        syntax = "./packages/package/classes/class[@name='%s'][1]" % class_name
+        syntax = "./packages/package/classes/class[@filename='%s'][1]" % class_name
         return self.xml.xpath(syntax)[0]
 
     @memoize
@@ -223,7 +223,7 @@ class Cobertura(object):
         """
         Return the list of available classes in the coverage report.
         """
-        return [el.attrib['name'] for el in self.xml.xpath("//class")]
+        return [el.attrib['filename'] for el in self.xml.xpath("//class")]
 
     def has_class(self, class_name):
         """

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -185,9 +185,9 @@ class Cobertura(object):
 
     def total_statements(self, class_filename=None):
         """
-        Return the total number of statements for the class file `class_filename`.
-        If `class_filename` is not given, return the total number of statements for
-        all class files.
+        Return the total number of statements for the class file
+        `class_filename`. If `class_filename` is not given, return the total
+        number of statements for all class files.
         """
         if class_filename is not None:
             statements = self._get_lines_by_class_filename(class_filename)
@@ -228,8 +228,8 @@ class Cobertura(object):
 
     def has_classfile(self, class_filename):
         """
-        Return `True` if the class file `class_filename` is present in the report,
-        return `False` otherwise.
+        Return `True` if the class file `class_filename` is present in the
+        report, return `False` otherwise.
         """
         # FIXME: this will lookup a list which is slow, make it O(1)
         return class_filename in self.class_files()
@@ -285,8 +285,9 @@ class CoberturaDiff(object):
 
     def _diff_attr(self, attr_name, class_filename):
         """
-        Return the difference between `self.cobertura2.<attr_name>(class_filename)`
-        and `self.cobertura1.<attr_name>(class_filename)`.
+        Return the difference between
+        `self.cobertura2.<attr_name>(class_filename)` and
+        `self.cobertura1.<attr_name>(class_filename)`.
 
         This generic method is meant to diff the count of methods that return
         counts for a given class name, e.g. `Cobertura.total_statements`,
@@ -326,9 +327,10 @@ class CoberturaDiff(object):
 
     def diff_missed_lines(self, class_filename):
         """
-        Return a list of 2-element tuples `(lineno, is_new)` for the given class
-        file `class_filename` where `lineno` is a missed line number and `is_new`
-        indicates whether the missed line was introduced (True) or removed (False).
+        Return a list of 2-element tuples `(lineno, is_new)` for the given
+        class file `class_filename` where `lineno` is a missed line number and
+        `is_new` indicates whether the missed line was introduced (True) or
+        removed (False).
         """
         line_changed = []
         for line in self.class_file_source(class_filename):
@@ -351,7 +353,8 @@ class CoberturaDiff(object):
         """
         if self.cobertura1.has_classfile(class_filename):
             lines1 = self.cobertura1.source_lines(class_filename)
-            line_statuses1 = dict(self.cobertura1.line_statuses(class_filename))
+            line_statuses1 = dict(self.cobertura1.line_statuses(
+                class_filename))
         else:
             lines1 = []
             line_statuses1 = {}
@@ -391,9 +394,10 @@ class CoberturaDiff(object):
 
     def class_source_hunks(self, class_filename):
         """
-        Like `CoberturaDiff.class_file_source`, but returns a list of line hunks of
-        the lines that have changed for the given `class_filename`. An empty list
-        means that the class has no lines that have a change in coverage status.
+        Like `CoberturaDiff.class_file_source`, but returns a list of line
+        hunks of the lines that have changed for the given `class_filename`.
+        An empty list means that the class has no lines that have a change in
+        coverage status.
         """
         lines = self.class_file_source(class_filename)
         hunks = hunkify_lines(lines)

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -53,7 +53,8 @@ class Reporter(object):
 
 class TextReporter(Reporter):
     def format_row(self, row):
-        class_filename, total_lines, total_misses, line_rate, missed_lines = row
+        class_filename, total_lines, total_misses, line_rate,\
+            missed_lines = row
 
         line_rate = '%.2f%%' % (line_rate * 100)
 

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -11,7 +11,7 @@ env.filters['line_status'] = filters.line_status_class
 env.filters['line_reason'] = filters.line_reason_icon
 
 row_attributes = [
-    'class_name',
+    'class_filename',
     'total_statements',
     'total_misses',
     'line_rate'
@@ -29,13 +29,13 @@ class Reporter(object):
     def get_report_lines(self):
         lines = []
 
-        for class_name in self.cobertura.classes():
+        for class_filename in self.cobertura.class_files():
             row = class_row_missed(
-                class_name,
-                self.cobertura.total_statements(class_name),
-                self.cobertura.total_misses(class_name),
-                self.cobertura.line_rate(class_name),
-                self.cobertura.missed_lines(class_name),
+                class_filename,
+                self.cobertura.total_statements(class_filename),
+                self.cobertura.total_misses(class_filename),
+                self.cobertura.line_rate(class_filename),
+                self.cobertura.missed_lines(class_filename),
             )
             lines.append(row)
 
@@ -53,7 +53,7 @@ class Reporter(object):
 
 class TextReporter(Reporter):
     def format_row(self, row):
-        class_name, total_lines, total_misses, line_rate, missed_lines = row
+        class_filename, total_lines, total_misses, line_rate, missed_lines = row
 
         line_rate = '%.2f%%' % (line_rate * 100)
 
@@ -67,7 +67,7 @@ class TextReporter(Reporter):
         formatted_missed_lines = ', '.join(formatted_missed_lines)
 
         row = class_row_missed(
-            class_name,
+            class_filename,
             total_lines,
             total_misses,
             line_rate,
@@ -86,7 +86,7 @@ class TextReporter(Reporter):
 
         report = tabulate(
             formatted_lines,
-            headers=['Name', 'Stmts', 'Miss', 'Cover', 'Missing']
+            headers=['Filename', 'Stmts', 'Miss', 'Cover', 'Missing']
         )
 
         return report
@@ -96,8 +96,8 @@ class HtmlReporter(TextReporter):
     def __init__(self, *args, **kwargs):
         super(HtmlReporter, self).__init__(*args, **kwargs)
 
-    def get_source(self, class_name):
-        lines = self.cobertura.class_source(class_name)
+    def get_source(self, class_filename):
+        lines = self.cobertura.class_file_source(class_filename)
         return lines
 
     def generate(self):
@@ -109,10 +109,9 @@ class HtmlReporter(TextReporter):
             formatted_lines.append(formatted_row)
 
         sources = []
-        for class_name in self.cobertura.classes():
-            source = self.get_source(class_name)
-            filename = self.cobertura.filename(class_name)
-            sources.append((class_name, filename, source))
+        for class_filename in self.cobertura.class_files():
+            source = self.get_source(class_filename)
+            sources.append((class_filename, source))
 
         template = env.get_template('html.jinja2')
         return template.render(
@@ -163,9 +162,9 @@ class DeltaReporter(object):
     def get_report_lines(self):
         lines = []
 
-        for class_name in self.differ.classes():
+        for class_name in self.differ.class_files():
             class_row = self.get_class_row(class_name)
-            if any(class_row[1:]):  # don't report unchanged classes
+            if any(class_row[1:]):  # don't report unchanged class files
                 lines.append(class_row)
 
         footer = self.get_footer_row()
@@ -214,7 +213,7 @@ class TextReporterDelta(DeltaReporter):
             missed_lines = ', '.join(missed_lines_colored)
 
         row = [
-            row.class_name,
+            row.class_filename,
             total_statements,
             total_misses,
             line_rate,
@@ -233,7 +232,7 @@ class TextReporterDelta(DeltaReporter):
             formatted_row = self.format_row(row)
             formatted_lines.append(formatted_row)
 
-        headers = ['Name', 'Stmts', 'Miss', 'Cover']
+        headers = ['Filename', 'Stmts', 'Miss', 'Cover']
 
         if self.show_source is True:
             headers.append('Missing')
@@ -247,8 +246,8 @@ class TextReporterDelta(DeltaReporter):
 
 
 class HtmlReporterDelta(TextReporterDelta):
-    def get_source_hunks(self, class_name):
-        hunks = self.differ.class_source_hunks(class_name)
+    def get_source_hunks(self, class_filename):
+        hunks = self.differ.class_source_hunks(class_filename)
         return hunks
 
     def format_row(self, row):
@@ -266,7 +265,7 @@ class HtmlReporterDelta(TextReporterDelta):
             ]
 
         row_values = [
-            row.class_name,
+            row.class_filename,
             total_statements,
             total_misses,
             line_rate,
@@ -290,12 +289,11 @@ class HtmlReporterDelta(TextReporterDelta):
 
         if self.show_source is True:
             sources = []
-            for class_name in self.differ.classes():
-                source_hunks = self.get_source_hunks(class_name)
+            for class_filename in self.differ.class_files():
+                source_hunks = self.get_source_hunks(class_filename)
                 if not source_hunks:
                     continue
-                filename = self.differ.filename(class_name)
-                sources.append((class_name, filename, source_hunks))
+                sources.append((class_filename, source_hunks))
 
         template = env.get_template('html-delta.jinja2')
 

--- a/pycobertura/templates/html-delta.jinja2
+++ b/pycobertura/templates/html-delta.jinja2
@@ -24,7 +24,7 @@ table.code td.lineno pre {margin-right: 1rem;}
       <table class="u-full-width">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Filename</th>
             <th>Stmts</th>
             <th>Miss</th>
             <th>Cover</th>
@@ -36,7 +36,7 @@ table.code td.lineno pre {margin-right: 1rem;}
         <tbody>
 {%- for line in lines %}
           <tr>
-            <td><a href="#{{ line.class_name }}">{{ line.class_name }}</a></td>
+            <td><a href="#{{ line.class_filename }}">{{ line.class_filename }}</a></td>
             <td>{{ line.total_statements }}</td>
             <td><span{% if line.total_misses != '-' %} class="{% if line.total_misses[0] == '+' %}red{% else %}green{% endif%}"{% endif %}>{{ line.total_misses }}</span></td>
             <td>{{ line.line_rate }}</td>
@@ -52,7 +52,7 @@ table.code td.lineno pre {margin-right: 1rem;}
         </tbody>
         <tfoot>
           <tr>
-            <td>{{ footer.class_name }}</td>
+            <td>{{ footer.class_filename }}</td>
             <td>{{ footer.total_statements }}</td>
             <td><span{% if footer.total_misses != '-' %} class="{% if footer.total_misses[0] == '+' %}red{% else %}green{% endif%}"{% endif %}>{{ footer.total_misses }}</span></td>
             <td>{{ footer.line_rate }}</td>
@@ -73,8 +73,8 @@ table.code td.lineno pre {margin-right: 1rem;}
   </dl>
 </div>
 
-{%- for class_name, filename, source_hunks in sources %}
-<h4 id="{{class_name}}">{{ class_name }}</h4>
+{%- for class_filename, source_hunks in sources %}
+<h4 id="{{class_filename}}">{{ class_filename }}</h4>
 {%- for hunk in source_hunks %}
 {{ render_source(hunk) }}
 {%- endfor %}

--- a/pycobertura/templates/html.jinja2
+++ b/pycobertura/templates/html.jinja2
@@ -16,7 +16,7 @@ pre {line-height: 1.3}
       <table class="u-full-width">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Filename</th>
             <th>Stmts</th>
             <th>Miss</th>
             <th>Cover</th>
@@ -26,7 +26,7 @@ pre {line-height: 1.3}
         <tbody>
 {%- for line in lines %}
           <tr>
-            <td><a href="#{{ line.class_name }}">{{ line.class_name }}</a></td>
+            <td><a href="#{{ line.class_filename }}">{{ line.class_filename }}</a></td>
             <td>{{ line.total_statements }}</td>
             <td>{{ line.total_misses }}</td>
             <td>{{ line.line_rate }}</td>
@@ -36,7 +36,7 @@ pre {line-height: 1.3}
         </tbody>
         <tfoot>
           <tr>
-            <td>{{ footer.class_name }}</td>
+            <td>{{ footer.class_filename }}</td>
             <td>{{ footer.total_statements }}</td>
             <td>{{ footer.total_misses }}</td>
             <td>{{ footer.line_rate }}</td>
@@ -45,8 +45,8 @@ pre {line-height: 1.3}
         </tfoot>
       </table>
 {%- from 'macro.source.jinja2' import render_source -%}
-{%- for class_name, filename, source in sources %}
-<h4 id="{{class_name}}">{{ class_name }}</h4>
+{%- for class_filename, source in sources %}
+<h4 id="{{class_filename}}">{{ class_filename }}</h4>
 {{ render_source(source) }}
 {%- endfor %}
     </div>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,11 +21,11 @@ def test_show__format_default():
         show, ['tests/dummy.original.xml'], catch_exceptions=False
     )
     assert result.output == """\
-Name              Stmts    Miss  Cover    Missing
---------------  -------  ------  -------  ---------
-dummy/__init__        0       0  0.00%
-dummy/dummy           4       2  50.00%   2, 5
-TOTAL                 4       2  50.00%
+Name                 Stmts    Miss  Cover    Missing
+-----------------  -------  ------  -------  ---------
+dummy/__init__.py        0       0  0.00%
+dummy/dummy.py           4       2  50.00%   2, 5
+TOTAL                    4       2  50.00%
 """
     assert result.exit_code == ExitCodes.OK
 
@@ -41,11 +41,11 @@ def test_show__format_text():
             catch_exceptions=False
         )
         assert result.output == """\
-Name              Stmts    Miss  Cover    Missing
---------------  -------  ------  -------  ---------
-dummy/__init__        0       0  0.00%
-dummy/dummy           4       2  50.00%   2, 5
-TOTAL                 4       2  50.00%
+Name                 Stmts    Miss  Cover    Missing
+-----------------  -------  ------  -------  ---------
+dummy/__init__.py        0       0  0.00%
+dummy/dummy.py           4       2  50.00%   2, 5
+TOTAL                    4       2  50.00%
 """
     assert result.exit_code == ExitCodes.OK
 
@@ -75,13 +75,13 @@ def test_show__output_to_file():
         os.remove('report.out')
         assert result.output == ""
         assert report == """\
-Name                         Stmts    Miss  Cover    Missing
--------------------------  -------  ------  -------  ---------
-Main                            11       0  100.00%
-search.BinarySearch             12       1  91.67%   24
-search.ISortedArraySearch        0       0  100.00%
-search.LinearSearch              7       2  71.43%   19-24
-TOTAL                           30       3  90.00%"""
+Name                              Stmts    Miss  Cover    Missing
+------------------------------  -------  ------  -------  ---------
+Main.java                            11       0  100.00%
+search/BinarySearch.java             12       1  91.67%   24
+search/ISortedArraySearch.java        0       0  100.00%
+search/LinearSearch.java              7       2  71.43%   19-24
+TOTAL                                30       3  90.00%"""
     assert result.exit_code == ExitCodes.OK
 
 
@@ -94,12 +94,12 @@ def test_diff__format_default():
         'tests/dummy.source2/coverage.xml',
     ], catch_exceptions=False)
     assert result.output == """\
-Name          Stmts      Miss  Cover    Missing
-------------  -------  ------  -------  ----------
-dummy/dummy   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
-dummy/dummy3  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL         +4           \x1b[31m+1\x1b[39m  +15.00%
+Name             Stmts      Miss  Cover    Missing
+---------------  -------  ------  -------  ----------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -115,12 +115,12 @@ def test_diff__format_text():
             'tests/dummy.source2/coverage.xml',
         ], catch_exceptions=False)
         assert result.output == """\
-Name          Stmts      Miss  Cover    Missing
-------------  -------  ------  -------  ----------
-dummy/dummy   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
-dummy/dummy3  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL         +4           \x1b[31m+1\x1b[39m  +15.00%
+Name             Stmts      Miss  Cover    Missing
+---------------  -------  ------  -------  ----------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -141,12 +141,12 @@ def test_diff__output_to_file():
         os.remove('report.out')
         assert result.output == ""
         assert report == """\
-Name          Stmts      Miss  Cover    Missing
-------------  -------  ------  -------  ----------
-dummy/dummy   -            -2  +40.00%  -5, -6
-dummy/dummy2  +2           +1  -25.00%  -2, -4, +5
-dummy/dummy3  +2           +2  -        +1, +2
-TOTAL         +4           +1  +15.00%"""
+Name             Stmts      Miss  Cover    Missing
+---------------  -------  ------  -------  ----------
+dummy/dummy.py   -            -2  +40.00%  -5, -6
+dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
+dummy/dummy3.py  +2           +2  -        +1, +2
+TOTAL            +4           +1  +15.00%"""
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
 
@@ -165,12 +165,12 @@ def test_diff__output_to_file__force_color():
     os.remove('report.out')
     assert result.output == ""
     assert report == """\
-Name          Stmts      Miss  Cover    Missing
-------------  -------  ------  -------  ----------
-dummy/dummy   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
-dummy/dummy3  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL         +4           \x1b[31m+1\x1b[39m  +15.00%"""
+Name             Stmts      Miss  Cover    Missing
+---------------  -------  ------  -------  ----------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%"""
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
 
@@ -184,12 +184,12 @@ def test_diff__format_text__with_color():
         'tests/dummy.source2/coverage.xml',
     ], catch_exceptions=False)
     assert result.output == """\
-Name          Stmts      Miss  Cover    Missing
-------------  -------  ------  -------  ----------
-dummy/dummy   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
-dummy/dummy3  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL         +4           \x1b[31m+1\x1b[39m  +15.00%
+Name             Stmts      Miss  Cover    Missing
+---------------  -------  ------  -------  ----------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -204,12 +204,12 @@ def test_diff__format_text__with_no_color():
         'tests/dummy.source2/coverage.xml',
     ], catch_exceptions=False)
     assert result.output == """\
-Name          Stmts      Miss  Cover    Missing
-------------  -------  ------  -------  ----------
-dummy/dummy   -            -2  +40.00%  -5, -6
-dummy/dummy2  +2           +1  -25.00%  -2, -4, +5
-dummy/dummy3  +2           +2  -        +1, +2
-TOTAL         +4           +1  +15.00%
+Name             Stmts      Miss  Cover    Missing
+---------------  -------  ------  -------  ----------
+dummy/dummy.py   -            -2  +40.00%  -5, -6
+dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
+dummy/dummy3.py  +2           +2  -        +1, +2
+TOTAL            +4           +1  +15.00%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def test_show__format_default():
         show, ['tests/dummy.original.xml'], catch_exceptions=False
     )
     assert result.output == """\
-Name                 Stmts    Miss  Cover    Missing
+Filename             Stmts    Miss  Cover    Missing
 -----------------  -------  ------  -------  ---------
 dummy/__init__.py        0       0  0.00%
 dummy/dummy.py           4       2  50.00%   2, 5
@@ -41,7 +41,7 @@ def test_show__format_text():
             catch_exceptions=False
         )
         assert result.output == """\
-Name                 Stmts    Miss  Cover    Missing
+Filename             Stmts    Miss  Cover    Missing
 -----------------  -------  ------  -------  ---------
 dummy/__init__.py        0       0  0.00%
 dummy/dummy.py           4       2  50.00%   2, 5
@@ -75,7 +75,7 @@ def test_show__output_to_file():
         os.remove('report.out')
         assert result.output == ""
         assert report == """\
-Name                              Stmts    Miss  Cover    Missing
+Filename                          Stmts    Miss  Cover    Missing
 ------------------------------  -------  ------  -------  ---------
 Main.java                            11       0  100.00%
 search/BinarySearch.java             12       1  91.67%   24
@@ -94,7 +94,7 @@ def test_diff__format_default():
         'tests/dummy.source2/coverage.xml',
     ], catch_exceptions=False)
     assert result.output == """\
-Name             Stmts      Miss  Cover    Missing
+Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ----------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
@@ -115,7 +115,7 @@ def test_diff__format_text():
             'tests/dummy.source2/coverage.xml',
         ], catch_exceptions=False)
         assert result.output == """\
-Name             Stmts      Miss  Cover    Missing
+Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ----------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
@@ -141,7 +141,7 @@ def test_diff__output_to_file():
         os.remove('report.out')
         assert result.output == ""
         assert report == """\
-Name             Stmts      Miss  Cover    Missing
+Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ----------
 dummy/dummy.py   -            -2  +40.00%  -5, -6
 dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
@@ -165,7 +165,7 @@ def test_diff__output_to_file__force_color():
     os.remove('report.out')
     assert result.output == ""
     assert report == """\
-Name             Stmts      Miss  Cover    Missing
+Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ----------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
@@ -184,7 +184,7 @@ def test_diff__format_text__with_color():
         'tests/dummy.source2/coverage.xml',
     ], catch_exceptions=False)
     assert result.output == """\
-Name             Stmts      Miss  Cover    Missing
+Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ----------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
@@ -204,7 +204,7 @@ def test_diff__format_text__with_no_color():
         'tests/dummy.source2/coverage.xml',
     ], catch_exceptions=False)
     assert result.output == """\
-Name             Stmts      Miss  Cover    Missing
+Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ----------
 dummy/dummy.py   -            -2  +40.00%  -5, -6
 dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5

--- a/tests/test_cobertura.py
+++ b/tests/test_cobertura.py
@@ -28,10 +28,10 @@ def test_line_rate():
 def test_line_rate_by_class():
     cobertura = make_cobertura()
     expected_line_rates = {
-        'Main': 1.0,
-        'search.BinarySearch': 0.9166666666666666,
-        'search.ISortedArraySearch': 1.0,
-        'search.LinearSearch': 0.7142857142857143,
+        'Main.java': 1.0,
+        'search/BinarySearch.java': 0.9166666666666666,
+        'search/ISortedArraySearch.java': 1.0,
+        'search/LinearSearch.java': 0.7142857142857143,
     }
 
     for class_name in cobertura.classes():
@@ -47,10 +47,10 @@ def test_branch_rate():
 def test_branch_rate_by_class():
     cobertura = make_cobertura()
     expected_branch_rates = {
-        'Main': 1.0,
-        'search.BinarySearch': 0.8333333333333334,
-        'search.ISortedArraySearch': 1.0,
-        'search.LinearSearch': 0.6666666666666666,
+        'Main.java': 1.0,
+        'search/BinarySearch.java': 0.8333333333333334,
+        'search/ISortedArraySearch.java': 1.0,
+        'search/LinearSearch.java': 0.6666666666666666,
     }
 
     for class_name in cobertura.classes():
@@ -61,10 +61,10 @@ def test_branch_rate_by_class():
 def test_missed_statements_by_class_name():
     cobertura = make_cobertura()
     expected_missed_statements = {
-        'Main': [],
-        'search.BinarySearch': [24],
-        'search.ISortedArraySearch': [],
-        'search.LinearSearch': [19, 24],
+        'Main.java': [],
+        'search/BinarySearch.java': [24],
+        'search/ISortedArraySearch.java': [],
+        'search/LinearSearch.java': [19, 24],
     }
 
     for class_name in cobertura.classes():
@@ -84,10 +84,10 @@ def test_list_classes():
 
     classes = cobertura.classes()
     assert classes == [
-        'Main',
-        'search.BinarySearch',
-        'search.ISortedArraySearch',
-        'search.LinearSearch'
+        'Main.java',
+        'search/BinarySearch.java',
+        'search/ISortedArraySearch.java',
+        'search/LinearSearch.java'
     ]
 
 
@@ -95,10 +95,10 @@ def test_hit_lines__by_iterating_over_classes():
     cobertura = make_cobertura()
 
     expected_lines = {
-        'Main': [10, 16, 17, 18, 19, 23, 25, 26, 28, 29, 30],
-        'search.BinarySearch': [12, 16, 18, 20, 21, 23, 25, 26, 28, 29, 31],
-        'search.ISortedArraySearch': [],
-        'search.LinearSearch': [9, 13, 15, 16, 17],
+        'Main.java': [10, 16, 17, 18, 19, 23, 25, 26, 28, 29, 30],
+        'search/BinarySearch.java': [12, 16, 18, 20, 21, 23, 25, 26, 28, 29, 31],
+        'search/ISortedArraySearch.java': [],
+        'search/LinearSearch.java': [9, 13, 15, 16, 17],
     }
 
     for class_name in cobertura.classes():
@@ -109,10 +109,10 @@ def test_missed_lines():
     cobertura = make_cobertura()
 
     expected_lines = {
-        'Main': [],
-        'search.BinarySearch': [24],
-        'search.ISortedArraySearch': [],
-        'search.LinearSearch': [19, 20, 21, 22, 23, 24],
+        'Main.java': [],
+        'search/BinarySearch.java': [24],
+        'search/ISortedArraySearch.java': [],
+        'search/LinearSearch.java': [19, 20, 21, 22, 23, 24],
     }
 
     for class_name in cobertura.classes():
@@ -127,10 +127,10 @@ def test_total_statements():
 def test_total_statements_by_class():
     cobertura = make_cobertura()
     expected_total_statements = {
-        'Main': 11,
-        'search.BinarySearch': 12,
-        'search.ISortedArraySearch': 0,
-        'search.LinearSearch': 7,
+        'Main.java': 11,
+        'search/BinarySearch.java': 12,
+        'search/ISortedArraySearch.java': 0,
+        'search/LinearSearch.java': 7,
     }
     for class_name in cobertura.classes():
         assert cobertura.total_statements(class_name) == \
@@ -145,10 +145,10 @@ def test_total_misses():
 def test_total_misses_by_class():
     cobertura = make_cobertura()
     expected_total_misses = {
-        'Main': 0,
-        'search.BinarySearch': 1,
-        'search.ISortedArraySearch': 0,
-        'search.LinearSearch': 2,
+        'Main.java': 0,
+        'search/BinarySearch.java': 1,
+        'search/ISortedArraySearch.java': 0,
+        'search/LinearSearch.java': 2,
     }
     for class_name in cobertura.classes():
         assert cobertura.total_misses(class_name) == \
@@ -163,10 +163,10 @@ def test_total_hits():
 def test_total_hits_by_class():
     cobertura = make_cobertura()
     expected_total_misses = {
-        'Main': 11,
-        'search.BinarySearch': 11,
-        'search.ISortedArraySearch': 0,
-        'search.LinearSearch': 5,
+        'Main.java': 11,
+        'search/BinarySearch.java': 11,
+        'search/ISortedArraySearch.java': 0,
+        'search/LinearSearch.java': 5,
     }
     for class_name in cobertura.classes():
         assert cobertura.total_hits(class_name) == \
@@ -176,10 +176,10 @@ def test_total_hits_by_class():
 def test_filename():
     cobertura = make_cobertura()
     expected_filenames = {
-        'Main': 'Main.java',
-        'search.BinarySearch': 'search/BinarySearch.java',
-        'search.ISortedArraySearch': 'search/ISortedArraySearch.java',
-        'search.LinearSearch': 'search/LinearSearch.java',
+        'Main.java': 'Main.java',
+        'search/BinarySearch.java': 'search/BinarySearch.java',
+        'search/ISortedArraySearch.java': 'search/ISortedArraySearch.java',
+        'search/LinearSearch.java': 'search/LinearSearch.java',
     }
     for class_name in cobertura.classes():
         assert cobertura.filename(class_name) == \
@@ -190,10 +190,10 @@ def test_filepath():
     base_path = 'foo/bar/baz'
     cobertura = make_cobertura(base_path=base_path)
     expected_filepaths = {
-        'Main': 'foo/bar/baz/Main.java',
-        'search.BinarySearch': 'foo/bar/baz/search/BinarySearch.java',
-        'search.ISortedArraySearch': 'foo/bar/baz/search/ISortedArraySearch.java',
-        'search.LinearSearch': 'foo/bar/baz/search/LinearSearch.java',
+        'Main.java': 'foo/bar/baz/Main.java',
+        'search/BinarySearch.java': 'foo/bar/baz/search/BinarySearch.java',
+        'search/ISortedArraySearch.java': 'foo/bar/baz/search/ISortedArraySearch.java',
+        'search/LinearSearch.java': 'foo/bar/baz/search/LinearSearch.java',
     }
     for class_name in cobertura.classes():
         assert cobertura.filepath(class_name) == \
@@ -204,10 +204,10 @@ def test_class_source__sources_not_found():
     from pycobertura.cobertura import Line
     cobertura = make_cobertura('tests/cobertura.xml')
     expected_sources = {
-        'Main': [Line(0, 'tests/Main.java not found', None, None)],
-        'search.BinarySearch': [Line(0, 'tests/search/BinarySearch.java not found', None, None)],
-        'search.ISortedArraySearch': [Line(0, 'tests/search/ISortedArraySearch.java not found', None, None)],
-        'search.LinearSearch': [Line(0, 'tests/search/LinearSearch.java not found', None, None)],
+        'Main.java': [Line(0, 'tests/Main.java not found', None, None)],
+        'search/BinarySearch.java': [Line(0, 'tests/search/BinarySearch.java not found', None, None)],
+        'search/ISortedArraySearch.java': [Line(0, 'tests/search/ISortedArraySearch.java not found', None, None)],
+        'search/LinearSearch.java': [Line(0, 'tests/search/LinearSearch.java not found', None, None)],
     }
     for class_name in cobertura.classes():
         assert cobertura.class_source(class_name) == expected_sources[class_name]
@@ -216,19 +216,19 @@ def test_class_source__sources_not_found():
 def test_line_statuses():
     cobertura = make_cobertura('tests/dummy.source1/coverage.xml')
     expected_line_statuses = {
-        'dummy/__init__': [],
-        'dummy/dummy': [
+        'dummy/__init__.py': [],
+        'dummy/dummy.py': [
             (1, True),
             (2, True),
             (4, True),
             (5, False),
             (6, False),
         ],
-        'dummy/dummy2': [
+        'dummy/dummy2.py': [
             (1, True),
             (2, True),
         ],
-        'dummy/dummy4': [
+        'dummy/dummy4.py': [
             (1, False),
             (2, False),
             (4, False),
@@ -245,8 +245,8 @@ def test_class_source__sources_found():
     from pycobertura.cobertura import Line
     cobertura = make_cobertura('tests/dummy.source1/coverage.xml')
     expected_sources = {
-        'dummy/__init__': [],
-        'dummy/dummy': [
+    'dummy/__init__.py': [],
+        'dummy/dummy.py': [
             Line(1, 'def foo():\n', True, None),
             Line(2, '    pass\n', True, None),
             Line(3, '\n', None, None),
@@ -254,11 +254,11 @@ def test_class_source__sources_found():
             Line(5, "    a = 'a'\n", False, None),
             Line(6, "    b = 'b'\n", False, None),
         ],
-        'dummy/dummy2': [
+        'dummy/dummy2.py': [
             Line(1, 'def baz():\n', True, None),
             Line(2, '    pass\n', True, None)
         ],
-        'dummy/dummy4': [
+        'dummy/dummy4.py': [
             Line(1, 'def barbaz():\n', False, None),
             Line(2, '    pass\n', False, None),
             Line(3, '\n', None, None),

--- a/tests/test_cobertura.py
+++ b/tests/test_cobertura.py
@@ -25,7 +25,7 @@ def test_line_rate():
     assert cobertura.line_rate() == 0.9
 
 
-def test_line_rate_by_class():
+def test_line_rate_by_class_file():
     cobertura = make_cobertura()
     expected_line_rates = {
         'Main.java': 1.0,
@@ -34,9 +34,9 @@ def test_line_rate_by_class():
         'search/LinearSearch.java': 0.7142857142857143,
     }
 
-    for class_name in cobertura.classes():
-        assert cobertura.line_rate(class_name) == \
-            expected_line_rates[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.line_rate(class_filename) == \
+            expected_line_rates[class_filename]
 
 
 def test_branch_rate():
@@ -44,7 +44,7 @@ def test_branch_rate():
     assert cobertura.branch_rate() == 0.75
 
 
-def test_branch_rate_by_class():
+def test_branch_rate_by_class_file():
     cobertura = make_cobertura()
     expected_branch_rates = {
         'Main.java': 1.0,
@@ -53,12 +53,12 @@ def test_branch_rate_by_class():
         'search/LinearSearch.java': 0.6666666666666666,
     }
 
-    for class_name in cobertura.classes():
-        assert cobertura.branch_rate(class_name) == \
-            expected_branch_rates[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.branch_rate(class_filename) == \
+            expected_branch_rates[class_filename]
 
 
-def test_missed_statements_by_class_name():
+def test_missed_statements_by_class_file():
     cobertura = make_cobertura()
     expected_missed_statements = {
         'Main.java': [],
@@ -67,9 +67,9 @@ def test_missed_statements_by_class_name():
         'search/LinearSearch.java': [19, 24],
     }
 
-    for class_name in cobertura.classes():
-        assert cobertura.missed_statements(class_name) == \
-            expected_missed_statements[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.missed_statements(class_filename) == \
+            expected_missed_statements[class_filename]
 
 
 def test_list_packages():
@@ -82,7 +82,7 @@ def test_list_packages():
 def test_list_classes():
     cobertura = make_cobertura()
 
-    classes = cobertura.classes()
+    classes = cobertura.class_files()
     assert classes == [
         'Main.java',
         'search/BinarySearch.java',
@@ -101,8 +101,8 @@ def test_hit_lines__by_iterating_over_classes():
         'search/LinearSearch.java': [9, 13, 15, 16, 17],
     }
 
-    for class_name in cobertura.classes():
-        assert cobertura.hit_statements(class_name) == expected_lines[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.hit_statements(class_filename) == expected_lines[class_filename]
 
 
 def test_missed_lines():
@@ -115,8 +115,8 @@ def test_missed_lines():
         'search/LinearSearch.java': [19, 20, 21, 22, 23, 24],
     }
 
-    for class_name in cobertura.classes():
-        assert cobertura.missed_lines(class_name) == expected_lines[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.missed_lines(class_filename) == expected_lines[class_filename]
 
 
 def test_total_statements():
@@ -124,7 +124,7 @@ def test_total_statements():
     assert cobertura.total_statements() == 30
 
 
-def test_total_statements_by_class():
+def test_total_statements_by_class_file():
     cobertura = make_cobertura()
     expected_total_statements = {
         'Main.java': 11,
@@ -132,9 +132,9 @@ def test_total_statements_by_class():
         'search/ISortedArraySearch.java': 0,
         'search/LinearSearch.java': 7,
     }
-    for class_name in cobertura.classes():
-        assert cobertura.total_statements(class_name) == \
-            expected_total_statements[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.total_statements(class_filename) == \
+            expected_total_statements[class_filename]
 
 
 def test_total_misses():
@@ -142,7 +142,7 @@ def test_total_misses():
     assert cobertura.total_misses() == 3
 
 
-def test_total_misses_by_class():
+def test_total_misses_by_class_file():
     cobertura = make_cobertura()
     expected_total_misses = {
         'Main.java': 0,
@@ -150,9 +150,9 @@ def test_total_misses_by_class():
         'search/ISortedArraySearch.java': 0,
         'search/LinearSearch.java': 2,
     }
-    for class_name in cobertura.classes():
-        assert cobertura.total_misses(class_name) == \
-            expected_total_misses[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.total_misses(class_filename) == \
+            expected_total_misses[class_filename]
 
 
 def test_total_hits():
@@ -160,7 +160,7 @@ def test_total_hits():
     assert cobertura.total_hits() == 27
 
 
-def test_total_hits_by_class():
+def test_total_hits_by_class_file():
     cobertura = make_cobertura()
     expected_total_misses = {
         'Main.java': 11,
@@ -168,22 +168,9 @@ def test_total_hits_by_class():
         'search/ISortedArraySearch.java': 0,
         'search/LinearSearch.java': 5,
     }
-    for class_name in cobertura.classes():
-        assert cobertura.total_hits(class_name) == \
-            expected_total_misses[class_name]
-
-
-def test_filename():
-    cobertura = make_cobertura()
-    expected_filenames = {
-        'Main.java': 'Main.java',
-        'search/BinarySearch.java': 'search/BinarySearch.java',
-        'search/ISortedArraySearch.java': 'search/ISortedArraySearch.java',
-        'search/LinearSearch.java': 'search/LinearSearch.java',
-    }
-    for class_name in cobertura.classes():
-        assert cobertura.filename(class_name) == \
-            expected_filenames[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.total_hits(class_filename) == \
+            expected_total_misses[class_filename]
 
 
 def test_filepath():
@@ -195,12 +182,12 @@ def test_filepath():
         'search/ISortedArraySearch.java': 'foo/bar/baz/search/ISortedArraySearch.java',
         'search/LinearSearch.java': 'foo/bar/baz/search/LinearSearch.java',
     }
-    for class_name in cobertura.classes():
-        assert cobertura.filepath(class_name) == \
-            expected_filepaths[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.filepath(class_filename) == \
+            expected_filepaths[class_filename]
 
 
-def test_class_source__sources_not_found():
+def test_class_file_source__sources_not_found():
     from pycobertura.cobertura import Line
     cobertura = make_cobertura('tests/cobertura.xml')
     expected_sources = {
@@ -209,8 +196,8 @@ def test_class_source__sources_not_found():
         'search/ISortedArraySearch.java': [Line(0, 'tests/search/ISortedArraySearch.java not found', None, None)],
         'search/LinearSearch.java': [Line(0, 'tests/search/LinearSearch.java not found', None, None)],
     }
-    for class_name in cobertura.classes():
-        assert cobertura.class_source(class_name) == expected_sources[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.class_file_source(class_filename) == expected_sources[class_filename]
 
 
 def test_line_statuses():
@@ -236,12 +223,12 @@ def test_line_statuses():
             (6, False)
         ],
     }
-    for class_name in cobertura.classes():
-        assert cobertura.line_statuses(class_name) == \
-            expected_line_statuses[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.line_statuses(class_filename) == \
+            expected_line_statuses[class_filename]
 
 
-def test_class_source__sources_found():
+def test_class_file_source__sources_found():
     from pycobertura.cobertura import Line
     cobertura = make_cobertura('tests/dummy.source1/coverage.xml')
     expected_sources = {
@@ -267,6 +254,6 @@ def test_class_source__sources_found():
             Line(6, '    pass\n', False, None)
         ],
     }
-    for class_name in cobertura.classes():
-        assert cobertura.class_source(class_name) == \
-            expected_sources[class_name]
+    for class_filename in cobertura.class_files():
+        assert cobertura.class_file_source(class_filename) == \
+               expected_sources[class_filename]

--- a/tests/test_cobertura_diff.py
+++ b/tests/test_cobertura_diff.py
@@ -10,8 +10,8 @@ def test_diff_class_source():
     differ = CoberturaDiff(cobertura1, cobertura2)
 
     expected_sources = {
-        'dummy/__init__': [],
-        'dummy/dummy': [
+        'dummy/__init__.py': [],
+        'dummy/dummy.py': [
             Line(1, u'def foo():\n', None, None),
             Line(2, u'    pass\n', None, None),
             Line(3, u'\n', None, None),
@@ -19,14 +19,14 @@ def test_diff_class_source():
             Line(5, u"    a = 'a'\n", True, 'cov-up'),
             Line(6, u"    d = 'd'\n", True, 'line-edit')
         ],
-        'dummy/dummy2': [
+        'dummy/dummy2.py': [
             Line(1, u'def baz():\n', None, None),
             Line(2, u"    c = 'c'\n", True, 'line-edit'),
             Line(3, u'\n', None, 'line-edit'),
             Line(4, u'def bat():\n', True, 'line-edit'),
             Line(5, u'    pass\n', False, 'cov-down')
         ],
-        'dummy/dummy3': [
+        'dummy/dummy3.py': [
             Line(1, u'def foobar():\n', False, 'line-edit'),
             Line(2, u'    pass  # This is a very long comment that was purposefully written so we could test how HTML rendering looks like when the boundaries of the page are reached. And here is a non-ascii char: \u015e\n', False, 'line-edit')
         ],
@@ -55,10 +55,10 @@ def test_diff_total_misses_by_class():
     differ = CoberturaDiff(cobertura1, cobertura2)
 
     expected_sources = {
-        'dummy/__init__': 0,
-        'dummy/dummy': -2,
-        'dummy/dummy2': 1,
-        'dummy/dummy3': 2,
+        'dummy/__init__.py': 0,
+        'dummy/dummy.py': -2,
+        'dummy/dummy2.py': 1,
+        'dummy/dummy3.py': 2,
     }
 
     for class_name in cobertura2.classes():
@@ -84,10 +84,10 @@ def test_diff_line_rate_by_class():
     differ = CoberturaDiff(cobertura1, cobertura2)
 
     expected_sources = {
-        'dummy/__init__': 0,
-        'dummy/dummy': 0.4,
-        'dummy/dummy2': -0.25,
-        'dummy/dummy3': 0.0,
+        'dummy/__init__.py': 0,
+        'dummy/dummy.py': 0.4,
+        'dummy/dummy2.py': -0.25,
+        'dummy/dummy3.py': 0.0,
     }
 
     for class_name in cobertura2.classes():
@@ -113,10 +113,10 @@ def test_diff_total_hits_by_class():
     differ = CoberturaDiff(cobertura1, cobertura2)
 
     expected_total_hits = {
-        'dummy/__init__': 0,
-        'dummy/dummy': 2,
-        'dummy/dummy2': 1,
-        'dummy/dummy3': 0,
+        'dummy/__init__.py': 0,
+        'dummy/dummy.py': 2,
+        'dummy/dummy2.py': 1,
+        'dummy/dummy3.py': 0,
     }
 
     for class_name in cobertura2.classes():

--- a/tests/test_cobertura_diff.py
+++ b/tests/test_cobertura_diff.py
@@ -32,9 +32,9 @@ def test_diff_class_source():
         ],
     }
 
-    for class_name in cobertura2.classes():
-        assert differ.class_source(class_name) == \
-            expected_sources[class_name]
+    for class_filename in cobertura2.class_files():
+        assert differ.class_file_source(class_filename) == \
+               expected_sources[class_filename]
 
 
 def test_diff_total_misses():
@@ -47,7 +47,7 @@ def test_diff_total_misses():
     assert differ.diff_total_misses() == 1
 
 
-def test_diff_total_misses_by_class():
+def test_diff_total_misses_by_class_file():
     from pycobertura.cobertura import CoberturaDiff
 
     cobertura1 = make_cobertura('tests/dummy.source1/coverage.xml')
@@ -61,9 +61,9 @@ def test_diff_total_misses_by_class():
         'dummy/dummy3.py': 2,
     }
 
-    for class_name in cobertura2.classes():
-        assert differ.diff_total_misses(class_name) == \
-            expected_sources[class_name]
+    for class_filename in cobertura2.class_files():
+        assert differ.diff_total_misses(class_filename) == \
+            expected_sources[class_filename]
 
 
 def test_diff_line_rate():
@@ -76,7 +76,7 @@ def test_diff_line_rate():
     assert differ.diff_line_rate() == 0.15000000000000002
 
 
-def test_diff_line_rate_by_class():
+def test_diff_line_rate_by_class_file():
     from pycobertura.cobertura import CoberturaDiff
 
     cobertura1 = make_cobertura('tests/dummy.source1/coverage.xml')
@@ -90,9 +90,9 @@ def test_diff_line_rate_by_class():
         'dummy/dummy3.py': 0.0,
     }
 
-    for class_name in cobertura2.classes():
-        assert differ.diff_line_rate(class_name) == \
-            expected_sources[class_name]
+    for class_filename in cobertura2.class_files():
+        assert differ.diff_line_rate(class_filename) == \
+            expected_sources[class_filename]
 
 
 def test_diff_total_hits():
@@ -105,7 +105,7 @@ def test_diff_total_hits():
     assert differ.diff_total_hits() == 3
 
 
-def test_diff_total_hits_by_class():
+def test_diff_total_hits_by_class_file():
     from pycobertura.cobertura import CoberturaDiff
 
     cobertura1 = make_cobertura('tests/dummy.source1/coverage.xml')
@@ -119,9 +119,9 @@ def test_diff_total_hits_by_class():
         'dummy/dummy3.py': 0,
     }
 
-    for class_name in cobertura2.classes():
-        assert differ.diff_total_hits(class_name) == \
-            expected_total_hits[class_name]
+    for class_filename in cobertura2.class_files():
+        assert differ.diff_total_hits(class_filename) == \
+            expected_total_hits[class_filename]
 
 
 def test_diff__has_all_changes_covered__some_changed_code_is_still_uncovered():

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -17,13 +17,13 @@ def test_text_report():
     report = TextReporter(cobertura)
 
     assert report.generate() == """\
-Name                         Stmts    Miss  Cover    Missing
--------------------------  -------  ------  -------  ---------
-Main                            11       0  100.00%
-search.BinarySearch             12       1  91.67%   24
-search.ISortedArraySearch        0       0  100.00%
-search.LinearSearch              7       2  71.43%   19-24
-TOTAL                           30       3  90.00%"""
+Name                              Stmts    Miss  Cover    Missing
+------------------------------  -------  ------  -------  ---------
+Main.java                            11       0  100.00%
+search/BinarySearch.java             12       1  91.67%   24
+search/ISortedArraySearch.java        0       0  100.00%
+search/LinearSearch.java              7       2  71.43%   19-24
+TOTAL                                30       3  90.00%"""
 
 
 def test_text_report__with_missing_range():
@@ -33,12 +33,12 @@ def test_text_report__with_missing_range():
     report = TextReporter(cobertura)
 
     assert report.generate() == """\
-Name              Stmts    Miss  Cover    Missing
---------------  -------  ------  -------  ---------
-dummy/__init__        0       0  0.00%
-dummy/dummy           4       0  100.00%
-dummy/dummy2          2       2  0.00%    1-2
-TOTAL                 6       2  66.67%"""
+Name                 Stmts    Miss  Cover    Missing
+-----------------  -------  ------  -------  ---------
+dummy/__init__.py        0       0  0.00%
+dummy/dummy.py           4       0  100.00%
+dummy/dummy2.py          2       2  0.00%    1-2
+TOTAL                    6       2  66.67%"""
 
 
 def test_text_report_delta__no_diff():
@@ -64,12 +64,12 @@ def test_text_report_delta__colorize_True():
     report_delta = TextReporterDelta(cobertura1, cobertura2, color=True)
 
     assert report_delta.generate() == """\
-Name          Stmts      Miss  Cover    Missing
-------------  -------  ------  -------  ----------
-dummy/dummy   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
-dummy/dummy3  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL         +4           \x1b[31m+1\x1b[39m  +15.00%"""
+Name             Stmts      Miss  Cover    Missing
+---------------  -------  ------  -------  ----------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%"""
 
 
 def test_text_report_delta__colorize_True__with_missing_range():
@@ -81,12 +81,12 @@ def test_text_report_delta__colorize_True__with_missing_range():
     report_delta = TextReporterDelta(cobertura1, cobertura2, color=True)
 
     assert report_delta.generate() == """\
-Name          Stmts      Miss  Cover    Missing
-------------  -------  ------  -------  ----------
-dummy/dummy   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
-dummy/dummy3  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL         +4           \x1b[31m+1\x1b[39m  +15.00%"""
+Name             Stmts      Miss  Cover    Missing
+---------------  -------  ------  -------  ----------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%"""
 
 
 def test_text_report_delta__colorize_False():
@@ -98,12 +98,12 @@ def test_text_report_delta__colorize_False():
     report_delta = TextReporterDelta(cobertura1, cobertura2, color=False)
 
     assert report_delta.generate() == """\
-Name          Stmts      Miss  Cover    Missing
-------------  -------  ------  -------  ----------
-dummy/dummy   -            -2  +40.00%  -5, -6
-dummy/dummy2  +2           +1  -25.00%  -2, -4, +5
-dummy/dummy3  +2           +2  -        +1, +2
-TOTAL         +4           +1  +15.00%"""
+Name             Stmts      Miss  Cover    Missing
+---------------  -------  ------  -------  ----------
+dummy/dummy.py   -            -2  +40.00%  -5, -6
+dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
+dummy/dummy3.py  +2           +2  -        +1, +2
+TOTAL            +4           +1  +15.00%"""
 
 
 def test_html_report():
@@ -136,28 +136,28 @@ def test_html_report():
         </thead>
         <tbody>
           <tr>
-            <td><a href="#Main">Main</a></td>
+            <td><a href="#Main.java">Main.java</a></td>
             <td>11</td>
             <td>0</td>
             <td>100.00%</td>
             <td></td>
           </tr>
           <tr>
-            <td><a href="#search.BinarySearch">search.BinarySearch</a></td>
+            <td><a href="#search/BinarySearch.java">search/BinarySearch.java</a></td>
             <td>12</td>
             <td>1</td>
             <td>91.67%</td>
             <td>24</td>
           </tr>
           <tr>
-            <td><a href="#search.ISortedArraySearch">search.ISortedArraySearch</a></td>
+            <td><a href="#search/ISortedArraySearch.java">search/ISortedArraySearch.java</a></td>
             <td>0</td>
             <td>0</td>
             <td>100.00%</td>
             <td></td>
           </tr>
           <tr>
-            <td><a href="#search.LinearSearch">search.LinearSearch</a></td>
+            <td><a href="#search/LinearSearch.java">search/LinearSearch.java</a></td>
             <td>7</td>
             <td>2</td>
             <td>71.43%</td>
@@ -174,7 +174,7 @@ def test_html_report():
           </tr>
         </tfoot>
       </table>
-<h4 id="Main">Main</h4>
+<h4 id="Main.java">Main.java</h4>
 <table class="code u-max-full-width">
   <tbody>
     <tr>
@@ -188,7 +188,7 @@ def test_html_report():
     </tr>
   </tbody>
 </table>
-<h4 id="search.BinarySearch">search.BinarySearch</h4>
+<h4 id="search/BinarySearch.java">search/BinarySearch.java</h4>
 <table class="code u-max-full-width">
   <tbody>
     <tr>
@@ -202,7 +202,7 @@ def test_html_report():
     </tr>
   </tbody>
 </table>
-<h4 id="search.ISortedArraySearch">search.ISortedArraySearch</h4>
+<h4 id="search/ISortedArraySearch.java">search/ISortedArraySearch.java</h4>
 <table class="code u-max-full-width">
   <tbody>
     <tr>
@@ -216,7 +216,7 @@ def test_html_report():
     </tr>
   </tbody>
 </table>
-<h4 id="search.LinearSearch">search.LinearSearch</h4>
+<h4 id="search/LinearSearch.java">search/LinearSearch.java</h4>
 <table class="code u-max-full-width">
   <tbody>
     <tr>
@@ -244,12 +244,12 @@ def test_text_report_delta__no_source():
     report_delta = TextReporterDelta(cobertura1, cobertura2, show_source=False)
     output = report_delta.generate()
     assert output == """\
-Name          Stmts      Miss  Cover
-------------  -------  ------  -------
-dummy/dummy   -            -2  +40.00%
-dummy/dummy2  +2           +1  -25.00%
-dummy/dummy3  +2           +2  -
-TOTAL         +4           +1  +15.00%"""
+Name             Stmts      Miss  Cover
+---------------  -------  ------  -------
+dummy/dummy.py   -            -2  +40.00%
+dummy/dummy2.py  +2           +1  -25.00%
+dummy/dummy3.py  +2           +2  -
+TOTAL            +4           +1  +15.00%"""
 
 
 def test_html_report_delta__no_source():
@@ -282,19 +282,19 @@ def test_html_report_delta__no_source():
         </thead>
         <tbody>
           <tr>
-            <td><a href="#dummy/dummy">dummy/dummy</a></td>
+            <td><a href="#dummy/dummy.py">dummy/dummy.py</a></td>
             <td>-</td>
             <td><span class="green">-2</span></td>
             <td>+40.00%</td>
           </tr>
           <tr>
-            <td><a href="#dummy/dummy2">dummy/dummy2</a></td>
+            <td><a href="#dummy/dummy2.py">dummy/dummy2.py</a></td>
             <td>+2</td>
             <td><span class="red">+1</span></td>
             <td>-25.00%</td>
           </tr>
           <tr>
-            <td><a href="#dummy/dummy3">dummy/dummy3</a></td>
+            <td><a href="#dummy/dummy3.py">dummy/dummy3.py</a></td>
             <td>+2</td>
             <td><span class="red">+2</span></td>
             <td>-</td>
@@ -347,7 +347,7 @@ def test_html_report_delta():
         </thead>
         <tbody>
           <tr>
-            <td><a href="#dummy/dummy">dummy/dummy</a></td>
+            <td><a href="#dummy/dummy.py">dummy/dummy.py</a></td>
             <td>-</td>
             <td><span class="green">-2</span></td>
             <td>+40.00%</td>
@@ -355,7 +355,7 @@ def test_html_report_delta():
             </td>
           </tr>
           <tr>
-            <td><a href="#dummy/dummy2">dummy/dummy2</a></td>
+            <td><a href="#dummy/dummy2.py">dummy/dummy2.py</a></td>
             <td>+2</td>
             <td><span class="red">+1</span></td>
             <td>-25.00%</td>
@@ -363,7 +363,7 @@ def test_html_report_delta():
             </td>
           </tr>
           <tr>
-            <td><a href="#dummy/dummy3">dummy/dummy3</a></td>
+            <td><a href="#dummy/dummy3.py">dummy/dummy3.py</a></td>
             <td>+2</td>
             <td><span class="red">+2</span></td>
             <td>-</td>
@@ -388,7 +388,7 @@ def test_html_report_delta():
     <dt><code>+</code></dt><dd>line added or modified</dd>
   </dl>
 </div>
-<h4 id="dummy/dummy">dummy/dummy</h4>
+<h4 id="dummy/dummy.py">dummy/dummy.py</h4>
 <table class="code u-max-full-width">
   <tbody>
     <tr>
@@ -411,7 +411,7 @@ def test_html_report_delta():
     </tr>
   </tbody>
 </table>
-<h4 id="dummy/dummy2">dummy/dummy2</h4>
+<h4 id="dummy/dummy2.py">dummy/dummy2.py</h4>
 <table class="code u-max-full-width">
   <tbody>
     <tr>
@@ -434,7 +434,7 @@ def test_html_report_delta():
     </tr>
   </tbody>
 </table>
-<h4 id="dummy/dummy3">dummy/dummy3</h4>
+<h4 id="dummy/dummy3.py">dummy/dummy3.py</h4>
 <table class="code u-max-full-width">
   <tbody>
     <tr>

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -17,7 +17,7 @@ def test_text_report():
     report = TextReporter(cobertura)
 
     assert report.generate() == """\
-Name                              Stmts    Miss  Cover    Missing
+Filename                          Stmts    Miss  Cover    Missing
 ------------------------------  -------  ------  -------  ---------
 Main.java                            11       0  100.00%
 search/BinarySearch.java             12       1  91.67%   24
@@ -33,7 +33,7 @@ def test_text_report__with_missing_range():
     report = TextReporter(cobertura)
 
     assert report.generate() == """\
-Name                 Stmts    Miss  Cover    Missing
+Filename             Stmts    Miss  Cover    Missing
 -----------------  -------  ------  -------  ---------
 dummy/__init__.py        0       0  0.00%
 dummy/dummy.py           4       0  100.00%
@@ -50,9 +50,9 @@ def test_text_report_delta__no_diff():
     report_delta = TextReporterDelta(cobertura1, cobertura2)
 
     assert report_delta.generate() == """\
-Name    Stmts    Miss    Cover    Missing
-------  -------  ------  -------  ---------
-TOTAL   -        -       -"""
+Filename    Stmts    Miss    Cover    Missing
+----------  -------  ------  -------  ---------
+TOTAL       -        -       -"""
 
 
 def test_text_report_delta__colorize_True():
@@ -64,7 +64,7 @@ def test_text_report_delta__colorize_True():
     report_delta = TextReporterDelta(cobertura1, cobertura2, color=True)
 
     assert report_delta.generate() == """\
-Name             Stmts      Miss  Cover    Missing
+Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ----------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
@@ -81,7 +81,7 @@ def test_text_report_delta__colorize_True__with_missing_range():
     report_delta = TextReporterDelta(cobertura1, cobertura2, color=True)
 
     assert report_delta.generate() == """\
-Name             Stmts      Miss  Cover    Missing
+Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ----------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
@@ -98,7 +98,7 @@ def test_text_report_delta__colorize_False():
     report_delta = TextReporterDelta(cobertura1, cobertura2, color=False)
 
     assert report_delta.generate() == """\
-Name             Stmts      Miss  Cover    Missing
+Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ----------
 dummy/dummy.py   -            -2  +40.00%  -5, -6
 dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
@@ -127,7 +127,7 @@ def test_html_report():
       <table class="u-full-width">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Filename</th>
             <th>Stmts</th>
             <th>Miss</th>
             <th>Cover</th>
@@ -244,7 +244,7 @@ def test_text_report_delta__no_source():
     report_delta = TextReporterDelta(cobertura1, cobertura2, show_source=False)
     output = report_delta.generate()
     assert output == """\
-Name             Stmts      Miss  Cover
+Filename         Stmts      Miss  Cover
 ---------------  -------  ------  -------
 dummy/dummy.py   -            -2  +40.00%
 dummy/dummy2.py  +2           +1  -25.00%
@@ -274,7 +274,7 @@ def test_html_report_delta__no_source():
       <table class="u-full-width">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Filename</th>
             <th>Stmts</th>
             <th>Miss</th>
             <th>Cover</th>
@@ -338,7 +338,7 @@ def test_html_report_delta():
       <table class="u-full-width">
         <thead>
           <tr>
-            <th>Name</th>
+            <th>Filename</th>
             <th>Stmts</th>
             <th>Miss</th>
             <th>Cover</th>


### PR DESCRIPTION
**Description:**

Changed cobertura's coverage.xml parsing behavior to lookup class elements by filename attribute for compatibility with coverage v3.7.1 and versions >=4.0.0 and updated the tests accordingly.

**Rationale:**

In newer versions of the coverage library (> 3.7.1), the coverage.xml class element's 'name' attribute has changed from containing the filepath w/o the extension ( ex. "project/view/myview" ) to the base filename only ( ex. "myview.py" ). The package path context is now represented within the package's name attribute only, which means collisions during name-based lookups are bound to occur ("project/view/\__init\__.py" and "project/\__init\__.py" for instance), which will cause the tool to report inaccurate results. Using the filename attribute for identification and lookups is an easy win for compatibility across versions 3.7.1 and up.

This hasn't impacted everyone internally *yet* since our current pip index only contains coverage 3.7.1, implicitly locking everyone's coverage testing to that version. However, it will affect all projects that don't have coverage version locked since pytest-cov requires `coverage>=3.7.1` and devpi provides the newest version it can find (4.0.2).

Edit: here's an [example](https://gist.github.com/JonSchuff/78f4d4ad3bb16bb8bf3a) of the coverage.xml changes.